### PR TITLE
Fix typo

### DIFF
--- a/src/SESMailSystem.php
+++ b/src/SESMailSystem.php
@@ -77,7 +77,7 @@ class SESMailSystem implements MailSystemInterface {
 					$pos = strpos($source, '<');
 					$name = trim(substr($source, 0, $pos));
 					$email = trim(strrchr($source, '<'));
-					$source = '=?utf8?q?' . str_replace(' ', '=20', quoted_printable_encode($name)) . '?= ' . $email;
+					$source = '=?utf-8?q?' . str_replace(' ', '=20', quoted_printable_encode($name)) . '?= ' . $email;
 				}
 				
 				$data = array();


### PR DESCRIPTION
Some mail providers will report an invalid header:

`Message is not RFC 5322 compliant: ‘From’ header is missing or malformed`